### PR TITLE
add duplicate step error type

### DIFF
--- a/messages.proto
+++ b/messages.proto
@@ -145,6 +145,7 @@ message StepValidateRequest {
 message StepValidateResponse {
     enum ErrorType {
         STEP_IMPLEMENTATION_NOT_FOUND = 0;
+        DUPLICATE_STEP_IMPLEMENTATION = 1;
     }
     required bool isValid = 1;
     optional string errorMessage = 2;


### PR DESCRIPTION
@mahendrakariya Just a little change to add another error type. I guess code generation should be run for all languages that use the protocol?

Related to : https://github.com/getgauge/gauge-java/pull/59