### PR TITLE
Go version update

### DIFF
--- a/go/gauge_messages/go.mod
+++ b/go/gauge_messages/go.mod
@@ -1,6 +1,6 @@
 module github.com/getgauge/gauge-proto/go/gauge_messages
 
-go 1.21.0
+go 1.21
 
 require (
 	google.golang.org/grpc v1.61.0


### PR DESCRIPTION
@sriv 
Set 'go 1.21' in go.mod to satisfy pipeline verification rules